### PR TITLE
Changed hardcoded home directory to `~`

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,13 +1,13 @@
 echo [-- Shutdown Tomcat Server --]
-/home/inferno/Tomcat/bin/shutdown.sh
+~/Tomcat/bin/shutdown.sh
 
 echo [-- Build WAR --]
 mvn clean install
 
 echo [-- Copy WAR --]
-rm /home/inferno/Tomcat/webapps/royale.war
-cp royale-client/target/client-1.0.war /home/inferno/Tomcat/webapps/royale.war
+rm ~/Tomcat/webapps/royale.war
+cp royale-client/target/client-1.0.war ~/Tomcat/webapps/royale.war
 
 echo [-- Start Tomcat Server --]
-/home/inferno/Tomcat/bin/startup.sh
+~/Tomcat/bin/startup.sh
 

--- a/royale-client/src/main/resources/noxio.properties
+++ b/royale-client/src/main/resources/noxio.properties
@@ -12,6 +12,6 @@
     "port": "7001"
   },
   "file": {
-    "path": "/home/inferno/.royale"
+    "path": "~/.royale"
   }
 }


### PR DESCRIPTION
In 2 files, the directory `/home/inferno`  is hardcoded. This should be `~` so that the inferno username isn't hardcoded.